### PR TITLE
Fix visitShuffleVectorInst

### DIFF
--- a/lib/Target/CBackend/CBackend.cpp
+++ b/lib/Target/CBackend/CBackend.cpp
@@ -3906,27 +3906,35 @@ void CWriter::visitExtractElementInst(ExtractElementInst &I) {
   Out << "]";
 }
 
+// <result> = shufflevector <n x <ty>> <v1>, <n x <ty>> <v2>, <m x i32> <mask>
+// ; yields <m x <ty>>
 void CWriter::visitShuffleVectorInst(ShuffleVectorInst &SVI) {
   Out << "(";
   printType(Out, SVI.getType());
   Out << "){ ";
   VectorType *VT = SVI.getType();
   unsigned NumElts = VT->getNumElements();
+  VectorType *InputVT = cast<VectorType>(SVI.getOperand(0)->getType());
+  unsigned NumInputElts = InputVT->getNumElements(); // n
   Type *EltTy = VT->getElementType();
 
   for (unsigned i = 0; i != NumElts; ++i) {
     if (i) Out << ", ";
     int SrcVal = SVI.getMaskValue(i);
-    if ((unsigned)SrcVal >= NumElts*2) {
+    if ((unsigned)SrcVal >= NumInputElts * 2) {
       Out << " 0/*undef*/ ";
     } else {
-      Value *Op = SVI.getOperand((unsigned)SrcVal >= NumElts);
+      // If SrcVal belongs [0, n - 1], it extracts value from <v1>
+      // If SrcVal belongs [n, 2 * n - 1], it extracts value from <v2>
+      // In C++, the value false is converted to zero and the value true is
+      // converted to one
+      Value *Op = SVI.getOperand((unsigned)SrcVal >= NumInputElts);
       if (isa<Instruction>(Op)) {
         // Do an extractelement of this value from the appropriate input.
         Out << "((";
         printType(Out, PointerType::getUnqual(EltTy));
         Out << ")(&" << GetValueName(Op)
-            << "))[" << (SrcVal & (NumElts-1)) << "]";
+            << "))[" << ((unsigned)SrcVal >= NumInputElts ? SrcVal - NumInputElts : SrcVal) << "]";
       } else if (isa<ConstantAggregateZero>(Op) || isa<UndefValue>(Op)) {
         Out << "0";
       } else {


### PR DESCRIPTION
There are some bugs of original implementation:
- 'if ((unsigned)SrcVal >= NumElts_2) {' should be 'if ((unsigned)SrcVal >= NumInputElts \* 2) {'. Because the original meaning of the condition is that CBE should print out " 0/_undef*/ " if the mask value greater than or equal to n \* 2
- '<< "))[" << (SrcVal & (NumElts-1)) << "]";' should be '<< "))[" << ((unsigned)SrcVal >= NumInputElts ? SrcVal - NumInputElts : SrcVal) << "]";' '(SrcVal & (NumElts-1))' is invalid when the NumElts equals 3
